### PR TITLE
More codegen stuff

### DIFF
--- a/lib/Cpp_gen.ml
+++ b/lib/Cpp_gen.ml
@@ -1,9 +1,9 @@
-open Mir
+open Cpp_gen_tree
 open Format
 
 let comma ppf () = fprintf ppf ", "
 let semi_new ppf () = fprintf ppf ";@ "
-let new_block ppf () = fprintf ppf "@[<v>@ @]"
+let new_block ppf () = fprintf ppf "@ " (* "@[<v>@ @]"*)
 let emit_str ppf s = fprintf ppf "%s" s
 
 let emit_option ?default:(d="") emitter ppf opt = match opt with
@@ -178,7 +178,7 @@ let%expect_test "class" =
       T__ log_prob(Eigen::Matrix<T__, -1, 1> params) {
         target += normal(multiply(x, params), 1.0);
       }
-       template <typename T__>
-       T__ grad_log_prob(Eigen::Matrix<T__, -1, 1> params) {
-         target += normal(multiply(x, params), 1.0);
-       }} |}];
+      template <typename T__>
+      T__ grad_log_prob(Eigen::Matrix<T__, -1, 1> params) {
+        target += normal(multiply(x, params), 1.0);
+      }} |}];

--- a/lib/Cpp_gen_tree.ml
+++ b/lib/Cpp_gen_tree.ml
@@ -2,8 +2,6 @@ open Core_kernel
 
 type litType = Int | Real | Str
 
-(* Probably need a way to go from something like a sourcemap to
-   current_statement_begin__?*)
 and cond_op =
   | Equals
   | NEquals
@@ -19,7 +17,6 @@ and expr =
   | Cond of expr * cond_op * expr
   | ArrayExpr of expr list (* array literal? *)
   | Indexed of expr * expr list
-  (* Do we need RowVector? CondFunApp?*)
 
 and infixop =
   | Plus

--- a/lib/Mir.ml
+++ b/lib/Mir.ml
@@ -2,15 +2,6 @@ open Core_kernel
 
 type litType = Int | Real | Str
 
-and sourceMap = {
-  file: string;
-  line_start: int;
-  line_end: int;
-  col_start: int;
-  col_end: int;
-}
-
-
 (* Probably need a way to go from something like a sourcemap to
    current_statement_begin__?*)
 and cond_op =
@@ -65,48 +56,20 @@ and statement =
   | Block of statement list
   | Decl of vardecl * expr option
 
-and stantype =
-  | SInt
-  | SReal
-  | SVector of expr option
-  | SRowVector of expr option
-  | SMatrix of (expr * expr) option
-  | SArray of stantype * expr option
-
-and transformation =
-  | Identity
-  | Lower of expr
-  | Upper of expr
-  | LowerUpper of expr * expr
-  | LocationScale of expr * expr
-  | Ordered
-  | PositiveOrdered
-  | Simplex
-  | UnitVector
-  | CholeskyCorr
-  | CholeskyCov
-  | Correlation
-  | Covariance
-
-and argmod = Data | ANone
-
 and fndef = {
-  returntype: stantype option;
+  returntype: string;
   name: string;
   arguments: vardecl list;
   body: statement;
 }
 
-and vardecl = stantype * string
-
-and block = (vardecl list) * (statement list)
+and vardecl = string * string
 
 and mir = {
   functions: fndef list;
   datafields: vardecl list;
   params: vardecl list;
-  transformations: string * transformation list;
-  ctor: statement list;
-  gq: block;
+  methods: fndef list;
+  ctor: (vardecl list) * statement list;
 }
 [@@deriving sexp, hash]

--- a/lib/Mir.ml
+++ b/lib/Mir.ml
@@ -56,14 +56,29 @@ and statement =
   | Block of statement list
   | Decl of vardecl * expr option
 
+and stantype =
+  | SInt
+  | SReal
+  | SArray of stantype
+  | SVector
+  | SRowVector
+  | SMatrix
+
+and autodiff_type =
+  | AVar of stantype
+  | AData of stantype
+
 and fndef = {
-  returntype: string;
+  returntype: autodiff_type option;
   name: string;
-  arguments: vardecl list;
+  arguments: ad_vardecl list;
   body: statement;
+  templates: string list;
 }
 
-and vardecl = string * string
+and ad_vardecl = autodiff_type * string
+
+and vardecl = stantype * string
 
 and mir = {
   functions: fndef list;

--- a/lib/Peep.ml
+++ b/lib/Peep.ml
@@ -1,3 +1,4 @@
+(*
 open Mir
 
 let rec log1m = function
@@ -7,3 +8,5 @@ let rec log1m = function
 
 let run_peephole_opts prog =
   prog |> log1m
+
+*)

--- a/lib/Stan_math_backend.ml
+++ b/lib/Stan_math_backend.ml
@@ -1,4 +1,4 @@
-open Mir
+(*open Mir
 open Core_kernel
 
 let stan_math_map =
@@ -12,7 +12,7 @@ let rec translate_fn_names = function
   | x -> x
 
 exception ShouldNeverHappen
-(*
+
 let prog_reader_call path =
   (* open the file and see how long it is and shit *)
   let


### PR DESCRIPTION
For the moment, going with the approach that we'll have a separate tree data structure that holds C++ specific information needed to generate C++ code, but not much Stan-specific stuff. It may make sense to either pull back and just use something closer to Stan, or push forward and eliminate any references to Stan from the C++ (right now they mostly exist in the types we allow in stantype).